### PR TITLE
Hello,

### DIFF
--- a/PanoHead_custom_colab.ipynb
+++ b/PanoHead_custom_colab.ipynb
@@ -1,23 +1,16 @@
 {
   "cells": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github"
-      },
-      "source": [
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/camenduru/PanoHead-colab/blob/main/PanoHead_custom_colab.ipynb)"
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "c-JdJwOaMWiS"
+        "id": "c-JdJwOaMWiS",
+        "collapsed": true
       },
       "outputs": [],
       "source": [
         "%cd /content\n",
+        "!mkdir /content/in /content/stage /content/output\n",
         "!git clone -b dev1 https://github.com/camenduru/PanoHead\n",
         "\n",
         "!apt -y install -qq aria2\n",
@@ -37,14 +30,15 @@
         "!cp /content/PanoHead/3DDFA_V2_cropping/recrop_images.py /content/3DDFA_V2\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/camenduru/shape_predictor_68_face_landmarks/resolve/main/shape_predictor_68_face_landmarks.dat -d /content/3DDFA_V2 -o shape_predictor_68_face_landmarks.dat\n",
-        "\n",
-        "!mkdir /content/in /content/stage /content/output"
+        "\n"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "CNjBZHu4GS9v"
+      },
       "outputs": [],
       "source": [
         "%cd /content/3DDFA_V2\n",
@@ -63,17 +57,21 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "4UvRp5ISGS9v"
+      },
       "outputs": [],
       "source": [
         "%cd /content/PanoHead\n",
-        "!python projector_withseg.py --num-steps=300 --num-steps-pti=300 --outdir=/content/output --target_img=/content/stage --network=/content/PanoHead/models/easy-khair-180-gpc0.8-trans10-025000.pkl --idx 0"
+        "!python projector_withseg.py --num-steps=400 --num-steps-pti=400 --outdir=/content/output --target_img=/content/stage --network=/content/PanoHead/models/easy-khair-180-gpc0.8-trans10-025000.pkl --idx 0"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "raOj_LhiGS9v"
+      },
       "outputs": [],
       "source": [
         "%cd /content/PanoHead\n",
@@ -83,12 +81,37 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "GbV41gL9GS9w"
+      },
       "outputs": [],
       "source": [
         "%cd /content/PanoHead\n",
-        "!python gen_videos_proj_withseg.py --output=/content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/PTI_render/post.mp4 --latent=/content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/projected_w.npz --trunc 0.7 --network /content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/fintuned_generator.pkl --shapes=true --cfg Head"
+        "!python gen_videos_proj_withseg.py --output=/content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/PTI_render/post.mp4 --latent=/content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/projected_w.npz --trunc 0.7 --network /content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/fintuned_generator.pkl --cfg Head --shapes 1 #--nrr 256"
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%cd /content/PanoHead\n",
+        "!python shape_utils.py /content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/PTI_render/ --level 25"
+      ],
+      "metadata": {
+        "id": "eZwL3cQcmpvt"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!export CUDA_LAUNCH_BLOCKING=1"
+      ],
+      "metadata": {
+        "id": "6UoU_xoQJQ84"
+      },
+      "execution_count": null,
+      "outputs": []
     }
   ],
   "metadata": {

--- a/PanoHead_custom_colab.ipynb
+++ b/PanoHead_custom_colab.ipynb
@@ -87,7 +87,7 @@
       "outputs": [],
       "source": [
         "%cd /content/PanoHead\n",
-        "!python gen_videos_proj_withseg.py --output=/content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/PTI_render/post.mp4 --latent=/content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/projected_w.npz --trunc 0.7 --network /content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/fintuned_generator.pkl --cfg Head"
+        "!python gen_videos_proj_withseg.py --output=/content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/PTI_render/post.mp4 --latent=/content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/projected_w.npz --trunc 0.7 --network /content/output/easy-khair-180-gpc0.8-trans10-025000.pkl/0/fintuned_generator.pkl --shapes=true --cfg Head"
       ]
     }
   ],


### PR DESCRIPTION
I made a small contribution to your project, and I have some feedback. While reviewing the project, I encountered a few issues:

/usr/local/lib/python3.10/dist-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /content/3DDFA_V2/FaceBoxes/utils/nms/cpu_nms.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
nms/cpu_nms.c: In function ‘__pyx_pf_3nms_7cpu_nms_2cpu_soft_nms’:
nms/cpu_nms.c:3556:33: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
 3556 |       __pyx_t_8 = ((__pyx_v_pos < __pyx_v_N) != 0);
      |                                 ^
nms/cpu_nms.c:4067:33: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
 4067 |       __pyx_t_8 = ((__pyx_v_pos < __pyx_v_N) != 0);
      |                                 ^
/usr/local/lib/python3.10/dist-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /content/3DDFA_V2/Sim3DR/lib/rasterize.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
In file included from /usr/local/lib/python3.10/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1960,
                 from /usr/local/lib/python3.10/dist-packages/numpy/core/include/numpy/ndarrayobject.h:12,
                 from /usr/local/lib/python3.10/dist-packages/numpy/core/include/numpy/arrayobject.h:5,
                 from lib/rasterize.cpp:766:
/usr/local/lib/python3.10/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
   17 | #warning "Using deprecated NumPy API, disable it with " \
      |  ^~~~~~~

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
a5a656|OK  |   384MiB/s|/content/3DDFA_V2/shape_predictor_68_face_landmarks.dat

Status Legend:
(OK):download completed.
[2]
13 sn.
%cd /content/3DDFA_V2
!rm -rf /content/stage/* /content/3DDFA_V2/crop_samples/img/* /content/3DDFA_V2/test/original/* /content/output/*
!cp /content/in/* /content/3DDFA_V2/test/original

!python dlib_kps.py
!python recrop_images.py -i data.pkl -j dataset.json

!cp -rf /content/3DDFA_V2/crop_samples/img/* /content/stage

# %cd /content/PanoHead

/content/3DDFA_V2
  0% 0/1 [00:01<?, ?it/s]
Traceback (most recent call last):
  File "/content/3DDFA_V2/recrop_images.py", line 322, in <module>
    main(args)
  File "/content/3DDFA_V2/recrop_images.py", line 291, in main
    cv2.imwrite(os.path.join(args.out_dir, os.path.basename(img_path).replace(".png",".jpg")), cropped_img)
cv2.error: OpenCV(4.7.0) /io/opencv/modules/imgcodecs/src/loadsave.cpp:783: error: (-215:Assertion failed) !_img.empty() in function 'imwrite'

cp: cannot stat '/content/3DDFA_V2/crop_samples/img/*': No such file or directory
